### PR TITLE
Add ca-certificates to packages to install

### DIFF
--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu trusty main' > /etc/apt/so
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286 && \
     apt-get update && \
     apt-get install -y --no-install-recommends cabal-install-1.22 ghc-7.10.1 happy-1.19.5 alex-3.1.4 \
-            zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev && \
+            zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH /root/.cabal/bin:/opt/cabal/1.22/bin:/opt/ghc/7.10.1/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.4/bin:$PATH

--- a/7.8/Dockerfile
+++ b/7.8/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu trusty main' > /etc/apt/so
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286 && \
     apt-get update && \
     apt-get install -y --no-install-recommends cabal-install-1.20 ghc-7.8.4 happy-1.19.4 alex-3.1.3 \
-            zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev && \
+            zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH /root/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:/opt/happy/1.19.4/bin:/opt/alex/3.1.3/bin:$PATH


### PR DESCRIPTION
Ran into issue https://github.com/freebroccolo/docker-haskell/issues/31 where common CA's were unknown. Adding ca-certificates to packages to installed resolved the issue. Fixes https://github.com/freebroccolo/docker-haskell/issues/31.