### PR TITLE
install profiling libraries

### DIFF
--- a/7.8/Dockerfile
+++ b/7.8/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG            C.UTF-8
 RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu trusty main' > /etc/apt/sources.list.d/ghc.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286 && \
     apt-get update && \
-    apt-get install -y --no-install-recommends cabal-install-1.20 ghc-7.8.4 happy-1.19.4 alex-3.1.3 \
+    apt-get install -y --no-install-recommends cabal-install-1.20 ghc-7.8.4 ghc-7.8.4-prof happy-1.19.4 alex-3.1.3 \
             zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This can make life easier if you end up wanting to do profiling. But I could see why it might not be wanted in a base image.