### PR TITLE
Install 'stack' using get.haskellstack.org

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -6,14 +6,12 @@ MAINTAINER Chris Biscardi <chris@christopherbiscardi.com>
 ENV LANG            C.UTF-8
 
 RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu trusty main' > /etc/apt/sources.list.d/ghc.list && \
-    echo 'deb http://download.fpcomplete.com/debian/jessie stable main'| tee /etc/apt/sources.list.d/fpco.list && \
     # hvr keys
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286 && \
-    # fpco keys
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
     apt-get update && \
     apt-get install -y --no-install-recommends cabal-install-1.24 ghc-8.0.1 happy-1.19.5 alex-3.1.7 \
-            stack zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++ git && \
+            zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++ git wget && \
+    wget -qO- https://get.haskellstack.org/ | sh && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/1.24/bin:/opt/ghc/8.0.1/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.7/bin:$PATH


### PR DESCRIPTION
FP Complete is phasing out their Debian package repositories,
so http://download.fpcomplete.com/debian/jessie will cease
to be updated at some point in the relatively near future.