### PR TITLE
8.4.3

### DIFF
--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -1,0 +1,28 @@
+## Dockerfile for a haskell environment
+FROM       debian:stretch
+
+## ensure locale is set during build
+ENV LANG            C.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git && \
+    echo 'deb http://downloads.haskell.org/debian stretch main' > /etc/apt/sources.list.d/ghc.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA3CBA3FFE22B574 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends ghc-8.4.3 cabal-install-2.2 \
+        zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v1.7.1/stack-1.7.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v1.7.1/stack-1.7.1-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \
+    apt-get purge -y --auto-remove curl && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz && \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
+    /usr/local/bin/stack config set system-ghc --global true && \
+    /usr/local/bin/stack config set install-ghc --global false && \
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/bin:/opt/ghc/bin:$PATH
+
+## run ghci by default unless a command is specified
+CMD ["ghci"]


### PR DESCRIPTION
* Upgrade to `debian:stretch` base.
* Switch from `hvr/ghc` PPA to `haskell.org` repository.
* Added `netbase` package to avoid Stack throwing
  "(no such protocol name: tcp)" error.
* Added `gnupg` and `dirmngr` to support gpg/apt-key.
* Upgrade Stack to the latest release.
* Set Stack `install-ghc` option to false to
  avoid installing other GHC versions.
* No longer ship `happy` and `alex` out of the box.